### PR TITLE
Fix errors on inter-region VPC peering connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 This repository contains terraform modules that can be used to deploy a VPC Peer.
 
 ## Module Listing
-- [VPC Peer](./modules/vpc_peer) - A terraform module for creating a VPC Peer within the same AWS account. 
-- [VPC Peer Cross Account](./modules/vpc_peer_cross_account) - A terraform module for creating a VPC Peer across different AWS accounts.
+- [VPC Peer](./modules/vpc_peer) - A Terraform module for creating a VPC Peer within the same AWS account.
+- [VPC Peer Cross Account / Inter-Region](./modules/vpc_peer_cross_account) - A Terraform module for creating a VPC Peer across different AWS accounts and/or regions.

--- a/modules/vpc_peer_cross_account/README.md
+++ b/modules/vpc_peer_cross_account/README.md
@@ -3,7 +3,9 @@
 ## Basic Usage
 This module requires AWS Credentials for the Acceptor account.
 
-To use the `cross_account.tf` example create a file called `secrets.tf` in the `example` folder and populate it with the following, replacing the X's with the Acceptor's account credentials.
+To use the `cross_account.tf` or `inter_region.tf` examples, create a file called `secrets.tf` in the `example` folder, and populate it with the following, replacing the X's with the Acceptor's account credentials.
+
+**NOTE:** To create an inter-region peering connection, specify the origin AWS account number as the value for the `peer_owner_id` parameter. You must also set the `is_inter_region` parameter to `true` in order to prevent the module from attempting to set unsupported peering connection options.
 
 ```
 variable "acceptor_access_key" {
@@ -24,6 +26,7 @@ variable "acceptor_secret_key" {
 | allow_remote_vpc_dns_resolution | Allow a local VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the peer VPC. | string | `true` | no |
 | auto_accept | Accept the peering (both VPCs need to be in the same AWS account). (OPTIONAL). | string | `false` | no |
 | environment | Application environment for which this network is being created. one of: ('Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test') | string | `Development` | no |
+| is_inter_region | Whether or not the VPC Peering connection being established is inter-region. | string | `false` | no |
 | peer_cidr_range | Peer VPC CIDR Range e.g. 172.19.0.0/16 | string | `172.19.0.0/16` | no |
 | peer_owner_id | The AWS account ID of the owner of the peer VPC. Defaults to the account ID the AWS provider is currently connected to. (OPTIONAL) | string | `` | no |
 | peer_region | The region of the accepter VPC of the [VPC Peering Connection]. auto_accept must be false, and use the aws_vpc_peering_connection_accepter to manage the accepter side. (OPTIONAL) | string | `` | no |

--- a/modules/vpc_peer_cross_account/examples/inter_region.tf
+++ b/modules/vpc_peer_cross_account/examples/inter_region.tf
@@ -1,0 +1,69 @@
+provider "aws" {
+  version = "~> 1.2"
+  region  = "us-west-2"
+}
+
+provider "aws" {
+  region = "us-east-1"
+  alias  = "peer"
+}
+
+module "base_network" {
+  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.1"
+  vpc_name            = "VPC-Peer-Origin"
+  cidr_range          = "172.18.0.0/16"
+  public_cidr_ranges  = ["172.18.168.0/22", "172.18.172.0/22"]
+  private_cidr_ranges = ["172.18.0.0/21", "172.18.8.0/21"]
+  custom_azs          = ["us-west-2a", "us-west-2b"]
+}
+
+module "base_network_target" {
+  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.1"
+  vpc_name            = "VPC-Peer-Target"
+  cidr_range          = "172.19.0.0/16"
+  public_cidr_ranges  = ["172.19.168.0/22", "172.19.172.0/22"]
+  private_cidr_ranges = ["172.19.0.0/21", "172.19.8.0/21"]
+  custom_azs          = ["us-east-1a", "us-east-1b"]
+
+  providers = {
+    aws = "aws.peer"
+  }
+}
+
+module "cross_account_vpc_peer" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_peer//modules/vpc_peer_cross_account?ref=v0.0.2"
+  vpc_id = "${module.base_network.vpc_id}"
+
+  is_inter_region = true
+
+  # VPC in acceptor account vpc-XXXXXXXXX
+  peer_vpc_id = "${module.base_network_target.vpc_id}"
+
+  # Acceptor account number
+  peer_owner_id = "XXXXXXXXXXXXX"
+
+  # Acceptor VPC Region
+  peer_region = "us-east-1"
+
+  # Acceptor Secret Key. Use a local secrets.tf file
+  acceptor_access_key = "${var.acceptor_access_key}"
+  acceptor_secret_key = "${var.acceptor_secret_key}"
+
+  vpc_cidr_range = "172.18.0.0/16"
+
+  # Acceptor cidr Range e.g. 172.19.0.0/16
+  peer_cidr_range = "172.19.0.0/16"
+
+  vpc_route_1_enable   = true
+  vpc_route_1_table_id = "${element(module.base_network.private_route_tables, 0)}"
+  vpc_route_2_enable   = true
+  vpc_route_2_table_id = "${element(module.base_network.private_route_tables, 1)}"
+
+  # Acceptor Route Tables
+  # Acceptor Route Table ID rtb-XXXXXXX
+  peer_route_1_enable = true
+
+  peer_route_1_table_id = "${element(module.base_network_target.private_route_tables, 0)}"
+  peer_route_2_enable   = true
+  peer_route_2_table_id = "${element(module.base_network_target.private_route_tables, 1)}"
+}

--- a/modules/vpc_peer_cross_account/main.tf
+++ b/modules/vpc_peer_cross_account/main.tf
@@ -42,6 +42,7 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
 # create an explicit dependency on the accepter.
 
 resource "aws_vpc_peering_connection_options" "requester" {
+  count                     = "${var.is_cross_region ? 0 : 1}"
   vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer.id}"
 
   requester {
@@ -50,6 +51,7 @@ resource "aws_vpc_peering_connection_options" "requester" {
 }
 
 resource "aws_vpc_peering_connection_options" "accepter" {
+  count                     = "${var.is_cross_region ? 0 : 1}"
   provider                  = "aws.peer"
   vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer.id}"
 

--- a/modules/vpc_peer_cross_account/variables.tf
+++ b/modules/vpc_peer_cross_account/variables.tf
@@ -54,6 +54,12 @@ variable "acceptor_secret_key" {
   type        = "string"
 }
 
+variable "is_inter_region" {
+  description = "Whether or not the VPC Peering connection being established is inter-region."
+  type        = "string"
+  default     = false
+}
+
 #########################
 #     VPC CIDR Range    #
 #########################


### PR DESCRIPTION
Using the cross-account module to create an inter-region VPC peering connection (whether or not it's within the same account) produces the following errors:

```
Error: Error applying plan:

2 error(s) occurred:

* module.cross_account_vpc_peer.aws_vpc_peering_connection_options.accepter: 1 error(s) occurred:

* aws_vpc_peering_connection_options.accepter: Error modifying VPC Peering Connection Options: OperationNotPermitted: Modifying VPC peering connection options AllowDnsResolutionFromRemoteVpc, AllowEgressFromLocalClassicLinkToRemoteVpc, AllowEgressFromLocalVpcToRemoteClassicLink is not supported for cross-region VPC peering connections
    status code: 400, request id: cd7f3215-b39c-4997-afc7-e35a073f024c
* module.cross_account_vpc_peer.aws_vpc_peering_connection_options.requester: 1 error(s) occurred:

* aws_vpc_peering_connection_options.requester: Error modifying VPC Peering Connection Options: OperationNotPermitted: Modifying VPC peering connection options AllowDnsResolutionFromRemoteVpc, AllowEgressFromLocalClassicLinkToRemoteVpc, AllowEgressFromLocalVpcToRemoteClassicLink is not supported for cross-region VPC peering connections
    status code: 400, request id: 95a4ebb5-563c-419e-9113-0210974b1bd9
```

This adds the `is_inter_region` flag which, when set to `true`, will refrain from attempting those modifications and prevent the errors.