### PR TITLE
Fix `is_cross_region` -> `is_inter_region` variable use

### DIFF
--- a/modules/vpc_peer_cross_account/main.tf
+++ b/modules/vpc_peer_cross_account/main.tf
@@ -42,7 +42,7 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
 # create an explicit dependency on the accepter.
 
 resource "aws_vpc_peering_connection_options" "requester" {
-  count                     = "${var.is_cross_region ? 0 : 1}"
+  count                     = "${var.is_inter_region ? 0 : 1}"
   vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer.id}"
 
   requester {
@@ -51,7 +51,7 @@ resource "aws_vpc_peering_connection_options" "requester" {
 }
 
 resource "aws_vpc_peering_connection_options" "accepter" {
-  count                     = "${var.is_cross_region ? 0 : 1}"
+  count                     = "${var.is_inter_region ? 0 : 1}"
   provider                  = "aws.peer"
   vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer.id}"
 


### PR DESCRIPTION
This was an oversight on my part in the original fix to inter-region VPC peering. I had used the "cross region" naming convention and updated it to be "inter region" in line with the AWS docs, but missed a couple of instances.