### PR TITLE
Updates - Docs,Examples,Provider and variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains terraform modules that can be used to deploy a VPC Peer.
 
+This module was tested against aws provider version `2.31.0` and minimally requires this version to produce expected results.
+
 ## Module Listing
 - [VPC Peer](./modules/vpc_peer) - A Terraform module for creating a VPC Peer within the same AWS account.
 - [VPC Peer Cross Account / Inter-Region](./modules/vpc_peer_cross_account) - A Terraform module for creating a VPC Peer across different AWS accounts and/or regions.

--- a/modules/vpc_peer/README.md
+++ b/modules/vpc_peer/README.md
@@ -1,6 +1,7 @@
-# aws-terraform-vpc_peer/modules/vpc_peer
+# aws-terraform-vpc\_peer/modules/vpc\_peer
 
-The module sets up a VPC peer within an AWS Account or in an alternate AWS Account.
+The module sets up a VPC peer in a single region and AWS Account. For inter region  
+and cross account VPC peering see the companion [cross account module ](../vpc\_peer\_cross\_account)
 
 ## Basic Usage
 
@@ -14,7 +15,7 @@ module "vpc_peer" {
  vpc_cidr_range                  = "172.18.0.0/16"
  peer_cidr_range                 = "10.0.0.0/16"
 
- #VPC Routes
+ #  VPC Routes
  vpc_route_1_enable   = true
  vpc_route_1_table_id = "${element(module.base_network.private_route_tables, 0)}"
  vpc_route_2_enable   = true
@@ -30,40 +31,44 @@ module "vpc_peer" {
 
 Full working references are available at [examples](examples)
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| allow\_remote\_vpc\_dns\_resolution | Allow a local VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the peer VPC. | string | `"true"` | no |
-| auto\_accept | Accept the peering (both VPCs need to be in the same AWS account). (OPTIONAL). | string | `"false"` | no |
-| environment | Application environment for which this network is being created. one of: ('Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test') | string | `"Development"` | no |
-| peer\_cidr\_range | Peer VPC CIDR Range e.g. 172.19.0.0/16 | string | `"172.19.0.0/16"` | no |
-| peer\_owner\_id | The AWS account ID of the owner of the peer VPC. Defaults to the account ID the AWS provider is currently connected to. (OPTIONAL) | string | `""` | no |
-| peer\_region | The region of the accepter VPC of the [VPC Peering Connection]. auto_accept must be false, and use the aws_vpc_peering_connection_accepter to manage the accepter side. (OPTIONAL) | string | `""` | no |
-| peer\_route\_1\_enable | Enables Peer Route Table 1. Allowed values: true, false | string | `"false"` | no |
-| peer\_route\_1\_table\_id | ID of VPC Route table #1 rtb-XXXXXX | string | `""` | no |
-| peer\_route\_2\_enable | Enables Peer Route Table 2. Allowed values: true, false | string | `"false"` | no |
-| peer\_route\_2\_table\_id | ID of VPC Route table #2 rtb-XXXXXX | string | `""` | no |
-| peer\_route\_3\_enable | Enables Peer Route Table 3. Allowed values: true, false | string | `"false"` | no |
-| peer\_route\_3\_table\_id | ID of VPC Route table #3 rtb-XXXXXX | string | `""` | no |
-| peer\_route\_4\_enable | Enables Peer Route Table 4. Allowed values: true, false | string | `"false"` | no |
-| peer\_route\_4\_table\_id | ID of VPC Route table #4 rtb-XXXXXX | string | `""` | no |
-| peer\_route\_5\_enable | Enables Peer Route Table 5. Allowed values: true, false | string | `"false"` | no |
-| peer\_route\_5\_table\_id | ID of VPC Route table #5 rtb-XXXXXX | string | `""` | no |
-| peer\_vpc\_id | The ID of the VPC with which you are creating the VPC Peering Connection. | string | n/a | yes |
-| tags | Custom tags to apply to all resources. | map | `<map>` | no |
-| vpc\_cidr\_range | VPC CIDR Range e.g. 172.18.0.0/16 | string | `"172.18.0.0/16"` | no |
-| vpc\_id | The ID of the requester VPC. | string | n/a | yes |
-| vpc\_route\_1\_enable | Enables VPC Route Table 1. Allowed values: true, false | string | `"false"` | no |
-| vpc\_route\_1\_table\_id | ID of VPC Route table #1 rtb-XXXXXX | string | `""` | no |
-| vpc\_route\_2\_enable | Enables VPC Route Table 2. Allowed values: true, false | string | `"false"` | no |
-| vpc\_route\_2\_table\_id | ID of VPC Route table #2 rtb-XXXXXX | string | `""` | no |
-| vpc\_route\_3\_enable | Enables VPC Route Table 3. Allowed values: true, false | string | `"false"` | no |
-| vpc\_route\_3\_table\_id | ID of VPC Route table #3 rtb-XXXXXX | string | `""` | no |
-| vpc\_route\_4\_enable | Enables VPC Route Table 4. Allowed values: true, false | string | `"false"` | no |
-| vpc\_route\_4\_table\_id | ID of VPC Route table #4 rtb-XXXXXX | string | `""` | no |
-| vpc\_route\_5\_enable | Enables VPC Route Table 5. Allowed values: true, false | string | `"false"` | no |
-| vpc\_route\_5\_table\_id | ID of VPC Route table #5 rtb-XXXXXX | string | `""` | no |
+|------|-------------|------|---------|:-----:|
+| allow\_remote\_vpc\_dns\_resolution | Allow a local VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the peer VPC. | `string` | `true` | no |
+| auto\_accept | Accept the peering. | `string` | `false` | no |
+| environment | Application environment for which this network is being created. one of: ('Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test') | `string` | `"Development"` | no |
+| peer\_cidr\_range | Peer VPC CIDR Range e.g. 172.19.0.0/16 | `string` | `"172.19.0.0/16"` | no |
+| peer\_route\_1\_enable | Enables Peer Route Table 1. Allowed values: true, false | `string` | `false` | no |
+| peer\_route\_1\_table\_id | ID of VPC Route table #1 rtb-XXXXXX | `string` | `""` | no |
+| peer\_route\_2\_enable | Enables Peer Route Table 2. Allowed values: true, false | `string` | `false` | no |
+| peer\_route\_2\_table\_id | ID of VPC Route table #2 rtb-XXXXXX | `string` | `""` | no |
+| peer\_route\_3\_enable | Enables Peer Route Table 3. Allowed values: true, false | `string` | `false` | no |
+| peer\_route\_3\_table\_id | ID of VPC Route table #3 rtb-XXXXXX | `string` | `""` | no |
+| peer\_route\_4\_enable | Enables Peer Route Table 4. Allowed values: true, false | `string` | `false` | no |
+| peer\_route\_4\_table\_id | ID of VPC Route table #4 rtb-XXXXXX | `string` | `""` | no |
+| peer\_route\_5\_enable | Enables Peer Route Table 5. Allowed values: true, false | `string` | `false` | no |
+| peer\_route\_5\_table\_id | ID of VPC Route table #5 rtb-XXXXXX | `string` | `""` | no |
+| peer\_vpc\_id | The ID of the VPC with which you are creating the VPC Peering Connection. | `string` | n/a | yes |
+| tags | Custom tags to apply to all resources. | `map` | `{}` | no |
+| vpc\_cidr\_range | VPC CIDR Range e.g. 172.18.0.0/16 | `string` | `"172.18.0.0/16"` | no |
+| vpc\_id | The ID of the requester VPC. | `string` | n/a | yes |
+| vpc\_route\_1\_enable | Enables VPC Route Table 1. Allowed values: true, false | `string` | `false` | no |
+| vpc\_route\_1\_table\_id | ID of VPC Route table #1 rtb-XXXXXX | `string` | `""` | no |
+| vpc\_route\_2\_enable | Enables VPC Route Table 2. Allowed values: true, false | `string` | `false` | no |
+| vpc\_route\_2\_table\_id | ID of VPC Route table #2 rtb-XXXXXX | `string` | `""` | no |
+| vpc\_route\_3\_enable | Enables VPC Route Table 3. Allowed values: true, false | `string` | `false` | no |
+| vpc\_route\_3\_table\_id | ID of VPC Route table #3 rtb-XXXXXX | `string` | `""` | no |
+| vpc\_route\_4\_enable | Enables VPC Route Table 4. Allowed values: true, false | `string` | `false` | no |
+| vpc\_route\_4\_table\_id | ID of VPC Route table #4 rtb-XXXXXX | `string` | `""` | no |
+| vpc\_route\_5\_enable | Enables VPC Route Table 5. Allowed values: true, false | `string` | `false` | no |
+| vpc\_route\_5\_table\_id | ID of VPC Route table #5 rtb-XXXXXX | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/vpc_peer/main.tf
+++ b/modules/vpc_peer/main.tf
@@ -1,12 +1,13 @@
 /**
 * # aws-terraform-vpc_peer/modules/vpc_peer
 *
-*The module sets up a VPC peer within an AWS Account or in an alternate AWS Account.
+* The module sets up a VPC peer in a single region and AWS Account. For inter region
+* and cross account VPC peering see the companion [cross account module ](../vpc_peer_cross_account)
 *
-*## Basic Usage
+* ## Basic Usage
 *
-*```
-*module "vpc_peer" {
+* ```
+* module "vpc_peer" {
 *  source                          = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_peer//modules/vpc_peer?ref=v0.0.2"
 *  vpc_id                          = "${module.base_network.vpc_id}"
 *  peer_vpc_id                     = "${module.peer_base_network.vpc_id}"
@@ -15,7 +16,7 @@
 *  vpc_cidr_range                  = "172.18.0.0/16"
 *  peer_cidr_range                 = "10.0.0.0/16"
 *
-*  #VPC Routes
+*  #  VPC Routes
 *  vpc_route_1_enable   = true
 *  vpc_route_1_table_id = "${element(module.base_network.private_route_tables, 0)}"
 *  vpc_route_2_enable   = true
@@ -26,8 +27,8 @@
 *  peer_route_1_table_id = "${element(module.peer_base_network.private_route_tables, 0)}"
 *  peer_route_2_enable   = true
 *  peer_route_2_table_id = "${element(module.peer_base_network.private_route_tables, 1)}"
-*}
-*```
+* }
+* ```
 *
 * Full working references are available at [examples](examples)
 *
@@ -41,11 +42,9 @@ locals {
 }
 
 resource "aws_vpc_peering_connection" "vpc_peer" {
-  peer_owner_id = "${var.peer_owner_id}"
-  peer_vpc_id   = "${var.peer_vpc_id}"
-  vpc_id        = "${var.vpc_id}"
-  auto_accept   = "${var.auto_accept}"
-  peer_region   = "${var.peer_region}"
+  peer_vpc_id = "${var.peer_vpc_id}"
+  vpc_id      = "${var.vpc_id}"
+  auto_accept = "${var.auto_accept}"
 
   accepter {
     allow_remote_vpc_dns_resolution = "${var.allow_remote_vpc_dns_resolution}"

--- a/modules/vpc_peer/variables.tf
+++ b/modules/vpc_peer/variables.tf
@@ -10,12 +10,6 @@ variable "tags" {
   default     = {}
 }
 
-variable "peer_owner_id" {
-  description = "The AWS account ID of the owner of the peer VPC. Defaults to the account ID the AWS provider is currently connected to. (OPTIONAL)"
-  type        = "string"
-  default     = ""
-}
-
 variable "peer_vpc_id" {
   description = "The ID of the VPC with which you are creating the VPC Peering Connection."
   type        = "string"
@@ -27,15 +21,9 @@ variable "vpc_id" {
 }
 
 variable "auto_accept" {
-  description = "Accept the peering (both VPCs need to be in the same AWS account). (OPTIONAL)."
+  description = "Accept the peering."
   type        = "string"
   default     = false
-}
-
-variable "peer_region" {
-  description = "The region of the accepter VPC of the [VPC Peering Connection]. auto_accept must be false, and use the aws_vpc_peering_connection_accepter to manage the accepter side. (OPTIONAL)"
-  type        = "string"
-  default     = ""
 }
 
 variable "allow_remote_vpc_dns_resolution" {

--- a/modules/vpc_peer_cross_account/README.md
+++ b/modules/vpc_peer_cross_account/README.md
@@ -1,16 +1,40 @@
-# aws-terraform-vpc_peer/modules/vpc_peer_cross_account
+# aws-terraform-vpc\_peer/modules/vpc\_peer\_cross\_account
 
-This module requires AWS Credentials for the Acceptor account.
+This module requires AWS Credentials for the Acceptor account in the cross account case. The IAM user must miminally have the below permissions to manage the entire lifecyle of the peering connection including route manipulation.
 
-To use the `cross_account.tf` or `inter_region.tf` examples, create a file called `secrets.tf` in the `example` folder, and populate it with the following, replacing the X's with the Acceptor's account credentials.
+```
+{
+   "Version": "2012-10-17",
+   "Statement": [
+       {
+           "Sid": "demo",
+           "Effect": "Allow",
+           "Action": [
+               "ec2:AcceptVpcPeeringConnection",
+               "ec2:CreateRoute",
+               "ec2:CreateTags",
+               "ec2:DeleteRoute",
+               "ec2:DescribeRouteTables",
+               "ec2:DescribeTags",
+               "ec2:DescribeVpcPeeringConnections",
+               "ec2:ModifyVpcPeeringConnectionOptions",
+               "ec2:RejectVpcPeeringConnection"
+          ],
+          "Resource": "*"
+       }
+   ]
+}
+```
 
-**NOTE:** To create an inter-region peering connection, specify the origin AWS account number as the value for the `peer_owner_id` parameter. You must also set the `is_inter_region` parameter to `true` in order to prevent the module from attempting to set unsupported peering connection options.
+**NOTE 1:** To use the `cross_account.tf` example create a file called `secrets.tf` similar to the `secrets.tf.example` file in the `examples` folder.
+
+**NOTE 2:** To create an inter-region peering connection, specify the origin AWS account number as the value for the `peer_owner_id` parameter.
 
 ## Basic Usage
 
 ```
 module "cross_account_vpc_peer" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_peer//modules/vpc_peer_cross_account?ref=v0.0.2"
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_peer//modules/vpc_peer_cross_account?ref=v0.0.4"
  vpc_id = "${module.base_network.vpc_id}"
 
  # VPC in acceptor account vpc-XXXXXXXXX
@@ -22,9 +46,11 @@ module "cross_account_vpc_peer" {
  # Acceptor VPC Region
  peer_region = "us-west-2"
 
- # Acceptor Secret Key. Use a local secrets.tf file
- acceptor_access_key = "${var.acceptor_access_key}"
- acceptor_secret_key = "${var.acceptor_secret_key}"
+ # Acceptor Access and Secret Key.
+ # These are added inline for clarity but should never be commited directly to the terraform config as seen here.
+ # Use a local secrets.tf as seen in example directory
+ acceptor_access_key = "ACCESS_KEY_HERE"
+ acceptor_secret_key = "SECRET_KEY_HERE"
 
  vpc_cidr_range = "172.18.0.0/16"
 
@@ -48,41 +74,50 @@ module "cross_account_vpc_peer" {
 
 Full working references are available at [examples](examples)
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| aws.peer | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| acceptor\_access\_key | An AWS Access Key with permissions to setup a VPC on the alternate account. | string | n/a | yes |
-| acceptor\_secret\_key | An AWS Secret Key with permissions to setup a VPC on the alternate account. | string | n/a | yes |
-| allow\_remote\_vpc\_dns\_resolution | Allow a local VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the peer VPC. | string | `"true"` | no |
-| auto\_accept | Accept the peering (both VPCs need to be in the same AWS account). (OPTIONAL). | string | `"false"` | no |
-| environment | Application environment for which this network is being created. one of: ('Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test') | string | `"Development"` | no |
-| is\_inter\_region | Whether or not the VPC Peering connection being established is inter-region. | string | `"false"` | no |
-| peer\_cidr\_range | Peer VPC CIDR Range e.g. 172.19.0.0/16 | string | `"172.19.0.0/16"` | no |
-| peer\_owner\_id | The AWS account ID of the owner of the peer VPC. Defaults to the account ID the AWS provider is currently connected to. (OPTIONAL) | string | `""` | no |
-| peer\_region | The region of the accepter VPC of the [VPC Peering Connection]. auto_accept must be false, and use the aws_vpc_peering_connection_accepter to manage the accepter side. (OPTIONAL) | string | `""` | no |
-| peer\_route\_1\_enable | Enables Peer Route Table 1. Allowed values: true, false | string | `"false"` | no |
-| peer\_route\_1\_table\_id | ID of VPC Route table #1 rtb-XXXXXX | string | `""` | no |
-| peer\_route\_2\_enable | Enables Peer Route Table 2. Allowed values: true, false | string | `"false"` | no |
-| peer\_route\_2\_table\_id | ID of VPC Route table #2 rtb-XXXXXX | string | `""` | no |
-| peer\_route\_3\_enable | Enables Peer Route Table 3. Allowed values: true, false | string | `"false"` | no |
-| peer\_route\_3\_table\_id | ID of VPC Route table #3 rtb-XXXXXX | string | `""` | no |
-| peer\_route\_4\_enable | Enables Peer Route Table 4. Allowed values: true, false | string | `"false"` | no |
-| peer\_route\_4\_table\_id | ID of VPC Route table #4 rtb-XXXXXX | string | `""` | no |
-| peer\_route\_5\_enable | Enables Peer Route Table 5. Allowed values: true, false | string | `"false"` | no |
-| peer\_route\_5\_table\_id | ID of VPC Route table #5 rtb-XXXXXX | string | `""` | no |
-| peer\_vpc\_id | The ID of the VPC with which you are creating the VPC Peering Connection. | string | n/a | yes |
-| tags | Custom tags to apply to all resources. | map | `<map>` | no |
-| vpc\_cidr\_range | VPC CIDR Range e.g. 172.18.0.0/16 | string | `"172.18.0.0/16"` | no |
-| vpc\_id | The ID of the requester VPC. | string | n/a | yes |
-| vpc\_route\_1\_enable | Enables VPC Route Table 1. Allowed values: true, false | string | `"false"` | no |
-| vpc\_route\_1\_table\_id | ID of VPC Route table #1 rtb-XXXXXX | string | `""` | no |
-| vpc\_route\_2\_enable | Enables VPC Route Table 2. Allowed values: true, false | string | `"false"` | no |
-| vpc\_route\_2\_table\_id | ID of VPC Route table #2 rtb-XXXXXX | string | `""` | no |
-| vpc\_route\_3\_enable | Enables VPC Route Table 3. Allowed values: true, false | string | `"false"` | no |
-| vpc\_route\_3\_table\_id | ID of VPC Route table #3 rtb-XXXXXX | string | `""` | no |
-| vpc\_route\_4\_enable | Enables VPC Route Table 4. Allowed values: true, false | string | `"false"` | no |
-| vpc\_route\_4\_table\_id | ID of VPC Route table #4 rtb-XXXXXX | string | `""` | no |
-| vpc\_route\_5\_enable | Enables VPC Route Table 5. Allowed values: true, false | string | `"false"` | no |
-| vpc\_route\_5\_table\_id | ID of VPC Route table #5 rtb-XXXXXX | string | `""` | no |
+|------|-------------|------|---------|:-----:|
+| acceptor\_access\_key | An AWS Access Key with permissions to setup a VPC on the alternate account. Only set for cross account use cases. | `string` | `""` | no |
+| acceptor\_secret\_key | An AWS Secret Key with permissions to setup a VPC on the alternate account. Only set for cross account use cases. | `string` | `""` | no |
+| allow\_remote\_vpc\_dns\_resolution | Allow a local VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the peer VPC. | `string` | `true` | no |
+| environment | Application environment for which this network is being created. one of: ('Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test') | `string` | `"Development"` | no |
+| peer\_cidr\_range | Peer VPC CIDR Range e.g. 172.19.0.0/16 | `string` | `"172.19.0.0/16"` | no |
+| peer\_owner\_id | The AWS account ID of the owner of the peer VPC. Defaults to the account ID the AWS provider is currently connected to. (OPTIONAL) | `string` | `""` | no |
+| peer\_region | The region of the accepter VPC of the [VPC Peering Connection]. | `string` | `""` | no |
+| peer\_route\_1\_enable | Enables Peer Route Table 1. Allowed values: true, false | `string` | `false` | no |
+| peer\_route\_1\_table\_id | ID of VPC Route table #1 rtb-XXXXXX | `string` | `""` | no |
+| peer\_route\_2\_enable | Enables Peer Route Table 2. Allowed values: true, false | `string` | `false` | no |
+| peer\_route\_2\_table\_id | ID of VPC Route table #2 rtb-XXXXXX | `string` | `""` | no |
+| peer\_route\_3\_enable | Enables Peer Route Table 3. Allowed values: true, false | `string` | `false` | no |
+| peer\_route\_3\_table\_id | ID of VPC Route table #3 rtb-XXXXXX | `string` | `""` | no |
+| peer\_route\_4\_enable | Enables Peer Route Table 4. Allowed values: true, false | `string` | `false` | no |
+| peer\_route\_4\_table\_id | ID of VPC Route table #4 rtb-XXXXXX | `string` | `""` | no |
+| peer\_route\_5\_enable | Enables Peer Route Table 5. Allowed values: true, false | `string` | `false` | no |
+| peer\_route\_5\_table\_id | ID of VPC Route table #5 rtb-XXXXXX | `string` | `""` | no |
+| peer\_vpc\_id | The ID of the VPC with which you are creating the VPC Peering Connection. | `string` | n/a | yes |
+| tags | Custom tags to apply to all resources. | `map` | `{}` | no |
+| vpc\_cidr\_range | VPC CIDR Range e.g. 172.18.0.0/16 | `string` | `"172.18.0.0/16"` | no |
+| vpc\_id | The ID of the requester VPC. | `string` | n/a | yes |
+| vpc\_route\_1\_enable | Enables VPC Route Table 1. Allowed values: true, false | `string` | `false` | no |
+| vpc\_route\_1\_table\_id | ID of VPC Route table #1 rtb-XXXXXX | `string` | `""` | no |
+| vpc\_route\_2\_enable | Enables VPC Route Table 2. Allowed values: true, false | `string` | `false` | no |
+| vpc\_route\_2\_table\_id | ID of VPC Route table #2 rtb-XXXXXX | `string` | `""` | no |
+| vpc\_route\_3\_enable | Enables VPC Route Table 3. Allowed values: true, false | `string` | `false` | no |
+| vpc\_route\_3\_table\_id | ID of VPC Route table #3 rtb-XXXXXX | `string` | `""` | no |
+| vpc\_route\_4\_enable | Enables VPC Route Table 4. Allowed values: true, false | `string` | `false` | no |
+| vpc\_route\_4\_table\_id | ID of VPC Route table #4 rtb-XXXXXX | `string` | `""` | no |
+| vpc\_route\_5\_enable | Enables VPC Route Table 5. Allowed values: true, false | `string` | `false` | no |
+| vpc\_route\_5\_table\_id | ID of VPC Route table #5 rtb-XXXXXX | `string` | `""` | no |
+
+## Outputs
+
+No output.
 

--- a/modules/vpc_peer_cross_account/examples/cross_account.tf
+++ b/modules/vpc_peer_cross_account/examples/cross_account.tf
@@ -1,10 +1,10 @@
 provider "aws" {
-  version = "~> 1.2"
+  version = "~> 2.31"
   region  = "us-west-2"
 }
 
 module "base_network" {
-  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.1"
+  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.10"
   vpc_name            = "VPC-Peer-Origin"
   cidr_range          = "172.18.0.0/16"
   public_cidr_ranges  = ["172.18.168.0/22", "172.18.172.0/22"]
@@ -12,26 +12,26 @@ module "base_network" {
 }
 
 module "cross_account_vpc_peer" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_peer//modules/vpc_peer_cross_account?ref=v0.0.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_peer//modules/vpc_peer_cross_account?ref=v0.0.4"
   vpc_id = "${module.base_network.vpc_id}"
 
   # VPC in acceptor account vpc-XXXXXXXXX
   peer_vpc_id = "vpc-XXXXXXXXX"
 
   # Acceptor account number
-  peer_owner_id = "XXXXXXXXXXXXX"
+  peer_owner_id = "99999999999999"
 
   # Acceptor VPC Region
-  peer_region = "us-west-2"
+  peer_region = "us-east-1"
 
   # Acceptor Secret Key. Use a local secrets.tf file
-  acceptor_access_key = "${var.acceptor_access_key}"
-  acceptor_secret_key = "${var.acceptor_secret_key}"
+  acceptor_access_key = "${local.acceptor_access_key}"
+  acceptor_secret_key = "${local.acceptor_secret_key}"
 
   vpc_cidr_range = "172.18.0.0/16"
 
   # Acceptor cidr Range e.g. 172.19.0.0/16
-  peer_cidr_range = "X.X.X.X/16"
+  peer_cidr_range = "172.31.0.0/16"
 
   vpc_route_1_enable   = true
   vpc_route_1_table_id = "${element(module.base_network.private_route_tables, 0)}"
@@ -42,7 +42,8 @@ module "cross_account_vpc_peer" {
   # Acceptor Route Table ID rtb-XXXXXXX
   peer_route_1_enable = true
 
-  peer_route_1_table_id = "rtb-XXXXX"
+  peer_route_1_table_id = "rtb-XXXXXX"
+
   peer_route_2_enable   = true
   peer_route_2_table_id = "rtb-XXXXX"
 }

--- a/modules/vpc_peer_cross_account/examples/secrets.tf.example
+++ b/modules/vpc_peer_cross_account/examples/secrets.tf.example
@@ -1,0 +1,4 @@
+  locals {
+  acceptor_access_key = "ACCESS_KEY"
+  acceptor_secret_key = "SECRET_KEY"
+  }

--- a/modules/vpc_peer_cross_account/variables.tf
+++ b/modules/vpc_peer_cross_account/variables.tf
@@ -26,14 +26,8 @@ variable "vpc_id" {
   type        = "string"
 }
 
-variable "auto_accept" {
-  description = "Accept the peering (both VPCs need to be in the same AWS account). (OPTIONAL)."
-  type        = "string"
-  default     = false
-}
-
 variable "peer_region" {
-  description = "The region of the accepter VPC of the [VPC Peering Connection]. auto_accept must be false, and use the aws_vpc_peering_connection_accepter to manage the accepter side. (OPTIONAL)"
+  description = "The region of the accepter VPC of the [VPC Peering Connection]."
   type        = "string"
   default     = ""
 }
@@ -45,19 +39,15 @@ variable "allow_remote_vpc_dns_resolution" {
 }
 
 variable "acceptor_access_key" {
-  description = "An AWS Access Key with permissions to setup a VPC on the alternate account."
+  description = "An AWS Access Key with permissions to setup a VPC on the alternate account. Only set for cross account use cases."
   type        = "string"
+  default     = ""
 }
 
 variable "acceptor_secret_key" {
-  description = "An AWS Secret Key with permissions to setup a VPC on the alternate account."
+  description = "An AWS Secret Key with permissions to setup a VPC on the alternate account. Only set for cross account use cases."
   type        = "string"
-}
-
-variable "is_inter_region" {
-  description = "Whether or not the VPC Peering connection being established is inter-region."
-  type        = "string"
-  default     = false
+  default     = ""
 }
 
 #########################

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -1,16 +1,16 @@
 provider "aws" {
-  version = "~> 1.2"
+  version = "~> 2.31"
   region  = "us-west-2"
 }
 
 provider "aws" {
-  version = "~> 1.2"
+  version = "~> 2.31"
   region  = "us-east-2"
   alias   = "ohio"
 }
 
 module "base_network" {
-  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=master"
+  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.10"
   vpc_name            = "VPC-Peer-Origin"
   cidr_range          = "172.18.0.0/16"
   public_cidr_ranges  = ["172.18.168.0/22", "172.18.172.0/22"]
@@ -18,7 +18,7 @@ module "base_network" {
 }
 
 module "peer_base_network" {
-  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=master"
+  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.10"
   vpc_name            = "VPC-Peer-Accepter"
   cidr_range          = "10.0.0.0/16"
   public_cidr_ranges  = ["10.0.1.0/24", "10.0.3.0/24"]
@@ -26,7 +26,7 @@ module "peer_base_network" {
 }
 
 module "remote_peer_base_network" {
-  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=master"
+  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.10"
   vpc_name            = "Remote-VPC-Peer-Accepter"
   cidr_range          = "192.168.0.0/16"
   public_cidr_ranges  = ["192.168.168.0/22", "192.168.172.0/22"]
@@ -50,13 +50,11 @@ data "aws_caller_identity" "current" {}
 module "cross_account_vpc_peer" {
   source = "../../module/modules/vpc_peer_cross_account"
 
-  vpc_id          = "${module.base_network.vpc_id}"
-  is_inter_region = true
-  peer_vpc_id     = "${module.remote_peer_base_network.vpc_id}"
-  peer_owner_id   = "${data.aws_caller_identity.current.account_id}"
-  peer_region     = "us-east-2"
+  vpc_id        = "${module.base_network.vpc_id}"
+  peer_vpc_id   = "${module.remote_peer_base_network.vpc_id}"
+  peer_owner_id = "${data.aws_caller_identity.current.account_id}"
+  peer_region   = "us-east-2"
 
-  auto_accept         = true
   acceptor_access_key = ""
   acceptor_secret_key = ""
 

--- a/tests/test1/outputs.tf
+++ b/tests/test1/outputs.tf
@@ -1,9 +1,0 @@
-output "peer_id_output" {
-  description = "ID of the VPC Peer"
-  value       = "${module.vpc_peer.id}"
-}
-
-output "accept_status_output" {
-  description = "Output of the Accect Status"
-  value       = "${module.vpc_peer.accept_status}"
-}


### PR DESCRIPTION
##### Corresponding Issue(s):

Addresses some concerns from: 
- https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/272
- https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/265

##### Summary of change(s):
- remove `auto_accept` variable from cross account module since its not compatible with that use case
-remove `peer_region`  variable from vpc_peer module as the advised use case is single region , same account deploys.
- remove `inter_region` variable and logic coupled with a documentation update to advise the module must be used with 2.31.0  or greater for proper usage
- updates to support using the latest testing container ( which has updated tuvok and terrafom-docs)
- update documentation advising with a sample IAM policy that  could be assigned to IAM user for cross account module and use case

##### Reason for Change(s):
-documentation was lacking a bit and the overall module needed a   refresh to reflect new provider functionality

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

Depending on variables set this is a incompatible change with prior version

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
no
##### If input variables or output variables have changed or has been added, have you updated the README?
yes
##### Do examples need to be updated based on changes?
yes
