### PR TITLE
Accept list of route tables in VPC Peer modules

### DIFF
--- a/modules/vpc_peer/README.md
+++ b/modules/vpc_peer/README.md
@@ -7,7 +7,7 @@ and cross account VPC peering see the companion [cross account module ](../vpc\_
 
 ```
 module "vpc_peer" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_peer//modules/vpc_peer?ref=v0.12.0"
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_peer//modules/vpc_peer?ref=v0.12.2"
 
  vpc_id                          = module.base_network.vpc_id
  peer_vpc_id                     = module.peer_base_network.vpc_id
@@ -15,16 +15,12 @@ module "vpc_peer" {
  allow_remote_vpc_dns_resolution = true
 
  #  VPC Routes
- vpc_route_1_enable   = true
- vpc_route_1_table_id = element(module.base_network.private_route_tables, 0)
- vpc_route_2_enable   = true
- vpc_route_2_table_id = element(module.base_network.private_route_tables, 1)
+ vpc_route_tables       = module.base_network.private_route_tables
+ vpc_route_tables_count = 2
 
  # Peer Routes
- peer_route_1_enable   = true
- peer_route_1_table_id = element(module.peer_base_network.private_route_tables, 0)
- peer_route_2_enable   = true
- peer_route_2_table_id = element(module.peer_base_network.private_route_tables, 1)
+ peer_route_tables       = module.peer_base_network.private_route_tables
+ peer_route_tables_count = 2
 }
 ```
 
@@ -42,6 +38,10 @@ The following module variables were removed and are no longer neccessary:
 - `peer_cidr_range`
 - `vpc_cidr_range`
 
+New variables `peer_route_tables` and `peer_route_tables_count` were added to replace the functionality of the various `peer_route_x_enable` and `peer_route_x_table_id` variables.  These deprecated variables and resources will continue to work as expected, but will be removed in a future release.
+
+New variables `vpc_route_tables` and `vpc_route_tables_count` were added to replace the functionality of the various `vpc_route_x_enable` and `vpc_route_x_table_id` variables.  These deprecated variables and resources will continue to work as expected, but will be removed in a future release.
+
 ## Providers
 
 | Name | Version |
@@ -55,29 +55,33 @@ The following module variables were removed and are no longer neccessary:
 | allow\_remote\_vpc\_dns\_resolution | Allow a local VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the peer VPC. | `bool` | `true` | no |
 | auto\_accept | Accept the peering. | `bool` | `false` | no |
 | environment | Application environment for which this network is being created. one of: ('Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test') | `string` | `"Development"` | no |
-| peer\_route\_1\_enable | Enables Peer Route Table 1. Allowed values: true, false | `bool` | `false` | no |
-| peer\_route\_1\_table\_id | ID of VPC Route table #1 rtb-XXXXXX | `string` | `""` | no |
-| peer\_route\_2\_enable | Enables Peer Route Table 2. Allowed values: true, false | `bool` | `false` | no |
-| peer\_route\_2\_table\_id | ID of VPC Route table #2 rtb-XXXXXX | `string` | `""` | no |
-| peer\_route\_3\_enable | Enables Peer Route Table 3. Allowed values: true, false | `bool` | `false` | no |
-| peer\_route\_3\_table\_id | ID of VPC Route table #3 rtb-XXXXXX | `string` | `""` | no |
-| peer\_route\_4\_enable | Enables Peer Route Table 4. Allowed values: true, false | `bool` | `false` | no |
-| peer\_route\_4\_table\_id | ID of VPC Route table #4 rtb-XXXXXX | `string` | `""` | no |
-| peer\_route\_5\_enable | Enables Peer Route Table 5. Allowed values: true, false | `bool` | `false` | no |
-| peer\_route\_5\_table\_id | ID of VPC Route table #5 rtb-XXXXXX | `string` | `""` | no |
+| peer\_route\_1\_enable | Enables Peer Route Table 1. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `bool` | `false` | no |
+| peer\_route\_1\_table\_id | ID of VPC Route table #1 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `string` | `""` | no |
+| peer\_route\_2\_enable | Enables Peer Route Table 2. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `bool` | `false` | no |
+| peer\_route\_2\_table\_id | ID of VPC Route table #2 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `string` | `""` | no |
+| peer\_route\_3\_enable | Enables Peer Route Table 3. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `bool` | `false` | no |
+| peer\_route\_3\_table\_id | ID of VPC Route table #3 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `string` | `""` | no |
+| peer\_route\_4\_enable | Enables Peer Route Table 4. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `bool` | `false` | no |
+| peer\_route\_4\_table\_id | ID of VPC Route table #4 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `string` | `""` | no |
+| peer\_route\_5\_enable | Enables Peer Route Table 5. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `bool` | `false` | no |
+| peer\_route\_5\_table\_id | ID of VPC Route table #5 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `string` | `""` | no |
+| peer\_route\_tables | A list of all peer route tables IDs | `list(string)` | `[]` | no |
+| peer\_route\_tables\_count | The number of peer route tables | `number` | `0` | no |
 | peer\_vpc\_id | The ID of the VPC with which you are creating the VPC Peering Connection. | `string` | n/a | yes |
 | tags | Custom tags to apply to all resources. | `map(string)` | `{}` | no |
 | vpc\_id | The ID of the requester VPC. | `string` | n/a | yes |
-| vpc\_route\_1\_enable | Enables VPC Route Table 1. Allowed values: true, false | `bool` | `false` | no |
-| vpc\_route\_1\_table\_id | ID of VPC Route table #1 rtb-XXXXXX | `string` | `""` | no |
-| vpc\_route\_2\_enable | Enables VPC Route Table 2. Allowed values: true, false | `bool` | `false` | no |
-| vpc\_route\_2\_table\_id | ID of VPC Route table #2 rtb-XXXXXX | `string` | `""` | no |
-| vpc\_route\_3\_enable | Enables VPC Route Table 3. Allowed values: true, false | `bool` | `false` | no |
-| vpc\_route\_3\_table\_id | ID of VPC Route table #3 rtb-XXXXXX | `string` | `""` | no |
-| vpc\_route\_4\_enable | Enables VPC Route Table 4. Allowed values: true, false | `bool` | `false` | no |
-| vpc\_route\_4\_table\_id | ID of VPC Route table #4 rtb-XXXXXX | `string` | `""` | no |
-| vpc\_route\_5\_enable | Enables VPC Route Table 5. Allowed values: true, false | `bool` | `false` | no |
-| vpc\_route\_5\_table\_id | ID of VPC Route table #5 rtb-XXXXXX | `string` | `""` | no |
+| vpc\_route\_1\_enable | Enables VPC Route Table 1. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `bool` | `false` | no |
+| vpc\_route\_1\_table\_id | ID of VPC Route table #1 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `string` | `""` | no |
+| vpc\_route\_2\_enable | Enables VPC Route Table 2. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `bool` | `false` | no |
+| vpc\_route\_2\_table\_id | ID of VPC Route table #2 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `string` | `""` | no |
+| vpc\_route\_3\_enable | Enables VPC Route Table 3. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `bool` | `false` | no |
+| vpc\_route\_3\_table\_id | ID of VPC Route table #3 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `string` | `""` | no |
+| vpc\_route\_4\_enable | Enables VPC Route Table 4. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `bool` | `false` | no |
+| vpc\_route\_4\_table\_id | ID of VPC Route table #4 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `string` | `""` | no |
+| vpc\_route\_5\_enable | Enables VPC Route Table 5. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `bool` | `false` | no |
+| vpc\_route\_5\_table\_id | ID of VPC Route table #5 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `string` | `""` | no |
+| vpc\_route\_tables | A list of all VPC route tables IDs | `list(string)` | `[]` | no |
+| vpc\_route\_tables\_count | The number of VPC route tables | `number` | `0` | no |
 
 ## Outputs
 

--- a/modules/vpc_peer/examples/vpc_peer.tf
+++ b/modules/vpc_peer/examples/vpc_peer.tf
@@ -17,7 +17,7 @@ module "base_network" {
 }
 
 module "peer_base_network" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.4"
 
   cidr_range          = "10.0.0.0/16"
   name                = "VPC-Peer-Accepter"
@@ -26,21 +26,15 @@ module "peer_base_network" {
 }
 
 module "vpc_peer" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_peer//modules/vpc_peer?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_peer//modules/vpc_peer?ref=v0.12.2"
 
   allow_remote_vpc_dns_resolution = true
   auto_accept                     = true
-  peer_cidr_range                 = "10.0.0.0/16"
-  peer_route_1_enable             = true
-  peer_route_1_table_id           = element(module.peer_base_network.private_route_tables, 0)
-  peer_route_2_enable             = true
-  peer_route_2_table_id           = element(module.peer_base_network.private_route_tables, 1)
+  peer_route_tables               = module.peer_base_network.private_route_tables
+  peer_route_tables_count         = 2
   peer_vpc_id                     = module.peer_base_network.vpc_id
   vpc_cidr_range                  = "172.18.0.0/16"
   vpc_id                          = module.base_network.vpc_id
-  vpc_route_1_enable              = true
-  vpc_route_1_table_id            = element(module.base_network.private_route_tables, 0)
-  vpc_route_2_enable              = true
-  vpc_route_2_table_id            = element(module.base_network.private_route_tables, 1)
+  vpc_route_tables                = module.base_network.private_route_tables
+  vpc_route_tables_count          = 2
 }
-

--- a/modules/vpc_peer/variables.tf
+++ b/modules/vpc_peer/variables.tf
@@ -16,62 +16,74 @@ variable "environment" {
   default     = "Development"
 }
 
+variable "peer_route_tables" {
+  description = "A list of all peer route tables IDs"
+  type        = list(string)
+  default     = []
+}
+
+variable "peer_route_tables_count" {
+  description = "The number of peer route tables"
+  type        = number
+  default     = 0
+}
+
 variable "peer_route_1_enable" {
-  description = "Enables Peer Route Table 1. Allowed values: true, false"
+  description = "Enables Peer Route Table 1. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "peer_route_1_table_id" {
-  description = "ID of VPC Route table #1 rtb-XXXXXX"
+  description = "ID of VPC Route table #1 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = string
   default     = ""
 }
 
 variable "peer_route_2_enable" {
-  description = "Enables Peer Route Table 2. Allowed values: true, false"
+  description = "Enables Peer Route Table 2. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "peer_route_2_table_id" {
-  description = "ID of VPC Route table #2 rtb-XXXXXX"
+  description = "ID of VPC Route table #2 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = string
   default     = ""
 }
 
 variable "peer_route_3_enable" {
-  description = "Enables Peer Route Table 3. Allowed values: true, false"
+  description = "Enables Peer Route Table 3. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "peer_route_3_table_id" {
-  description = "ID of VPC Route table #3 rtb-XXXXXX"
+  description = "ID of VPC Route table #3 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = string
   default     = ""
 }
 
 variable "peer_route_4_enable" {
-  description = "Enables Peer Route Table 4. Allowed values: true, false"
+  description = "Enables Peer Route Table 4. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "peer_route_4_table_id" {
-  description = "ID of VPC Route table #4 rtb-XXXXXX"
+  description = "ID of VPC Route table #4 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = string
   default     = ""
 }
 
 variable "peer_route_5_enable" {
-  description = "Enables Peer Route Table 5. Allowed values: true, false"
+  description = "Enables Peer Route Table 5. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "peer_route_5_table_id" {
-  description = "ID of VPC Route table #5 rtb-XXXXXX"
+  description = "ID of VPC Route table #5 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = string
   default     = ""
 }
@@ -92,62 +104,74 @@ variable "vpc_id" {
   type        = string
 }
 
+variable "vpc_route_tables" {
+  description = "A list of all VPC route tables IDs"
+  type        = list(string)
+  default     = []
+}
+
+variable "vpc_route_tables_count" {
+  description = "The number of VPC route tables"
+  type        = number
+  default     = 0
+}
+
 variable "vpc_route_1_enable" {
-  description = "Enables VPC Route Table 1. Allowed values: true, false"
+  description = "Enables VPC Route Table 1. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "vpc_route_1_table_id" {
-  description = "ID of VPC Route table #1 rtb-XXXXXX"
+  description = "ID of VPC Route table #1 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = string
   default     = ""
 }
 
 variable "vpc_route_2_enable" {
-  description = "Enables VPC Route Table 2. Allowed values: true, false"
+  description = "Enables VPC Route Table 2. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "vpc_route_2_table_id" {
-  description = "ID of VPC Route table #2 rtb-XXXXXX"
+  description = "ID of VPC Route table #2 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = string
   default     = ""
 }
 
 variable "vpc_route_3_enable" {
-  description = "Enables VPC Route Table 3. Allowed values: true, false"
+  description = "Enables VPC Route Table 3. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "vpc_route_3_table_id" {
-  description = "ID of VPC Route table #3 rtb-XXXXXX"
+  description = "ID of VPC Route table #3 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = string
   default     = ""
 }
 
 variable "vpc_route_4_enable" {
-  description = "Enables VPC Route Table 4. Allowed values: true, false"
+  description = "Enables VPC Route Table 4. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "vpc_route_4_table_id" {
-  description = "ID of VPC Route table #4 rtb-XXXXXX"
+  description = "ID of VPC Route table #4 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = string
   default     = ""
 }
 
 variable "vpc_route_5_enable" {
-  description = "Enables VPC Route Table 5. Allowed values: true, false"
+  description = "Enables VPC Route Table 5. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "vpc_route_5_table_id" {
-  description = "ID of VPC Route table #5 rtb-XXXXXX"
+  description = "ID of VPC Route table #5 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = string
   default     = ""
 }

--- a/modules/vpc_peer_cross_account/README.md
+++ b/modules/vpc_peer_cross_account/README.md
@@ -31,25 +31,19 @@ can be used to create the required role.
 
 ```HCL
 module "cross_account_vpc_peer" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_peer//modules/vpc_peer_cross_account?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_peer//modules/vpc_peer_cross_account?ref=v0.12.2"
 
   vpc_id = module.base_network.vpc_id
 
   # VPC in acceptor account vpc-XXXXXXXXX
-  peer_vpc_id = "vpc-XXXXXXXXX"
+  peer_vpc_id = module.peer_base_network.vpc_id
 
-  vpc_route_1_enable   = true
-  vpc_route_1_table_id = element(module.base_network.private_route_tables, 0)
-  vpc_route_2_enable   = true
-  vpc_route_2_table_id = element(module.base_network.private_route_tables, 1)
+  vpc_route_tables       = module.base_network.private_route_tables
+  vpc_route_tables_count = 2
 
   # Acceptor Route Tables
-  # Acceptor Route Table ID rtb-XXXXXXX
-  peer_route_1_enable = true
-
-  peer_route_1_table_id = "rtb-XXXXX"
-  peer_route_2_enable   = true
-  peer_route_2_table_id = "rtb-XXXXX"
+  peer_route_tables       = module.peer_base_network.private_route_tables
+  peer_route_tables_count = 2
 
   providers = {
     aws.peer = aws.peer
@@ -106,6 +100,10 @@ The following module variables were removed and are no longer neccessary:
 - `peer_region`
 - `vpc_cidr_range`
 
+New variables `peer_route_tables` and `peer_route_tables_count` were added to replace the functionality of the various `peer_route_x_enable` and `peer_route_x_table_id` variables.  These deprecated variables and resources will continue to work as expected, but will be removed in a future release.
+
+New variables `vpc_route_tables` and `vpc_route_tables_count` were added to replace the functionality of the various `vpc_route_x_enable` and `vpc_route_x_table_id` variables.  These deprecated variables and resources will continue to work as expected, but will be removed in a future release.
+
 ## Providers
 
 | Name | Version |
@@ -119,29 +117,33 @@ The following module variables were removed and are no longer neccessary:
 |------|-------------|------|---------|:-----:|
 | allow\_remote\_vpc\_dns\_resolution | Allow a local VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the peer VPC. | `bool` | `true` | no |
 | environment | Application environment for which this network is being created. one of: ('Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test') | `string` | `"Development"` | no |
-| peer\_route\_1\_enable | Enables Peer Route Table 1. Allowed values: true, false | `bool` | `false` | no |
-| peer\_route\_1\_table\_id | ID of VPC Route table #1 rtb-XXXXXX | `string` | `""` | no |
-| peer\_route\_2\_enable | Enables Peer Route Table 2. Allowed values: true, false | `bool` | `false` | no |
-| peer\_route\_2\_table\_id | ID of VPC Route table #2 rtb-XXXXXX | `string` | `""` | no |
-| peer\_route\_3\_enable | Enables Peer Route Table 3. Allowed values: true, false | `bool` | `false` | no |
-| peer\_route\_3\_table\_id | ID of VPC Route table #3 rtb-XXXXXX | `string` | `""` | no |
-| peer\_route\_4\_enable | Enables Peer Route Table 4. Allowed values: true, false | `bool` | `false` | no |
-| peer\_route\_4\_table\_id | ID of VPC Route table #4 rtb-XXXXXX | `string` | `""` | no |
-| peer\_route\_5\_enable | Enables Peer Route Table 5. Allowed values: true, false | `bool` | `false` | no |
-| peer\_route\_5\_table\_id | ID of VPC Route table #5 rtb-XXXXXX | `string` | `""` | no |
+| peer\_route\_1\_enable | Enables Peer Route Table 1. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `bool` | `false` | no |
+| peer\_route\_1\_table\_id | ID of VPC Route table #1 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `string` | `""` | no |
+| peer\_route\_2\_enable | Enables Peer Route Table 2. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `bool` | `false` | no |
+| peer\_route\_2\_table\_id | ID of VPC Route table #2 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `string` | `""` | no |
+| peer\_route\_3\_enable | Enables Peer Route Table 3. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `bool` | `false` | no |
+| peer\_route\_3\_table\_id | ID of VPC Route table #3 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `string` | `""` | no |
+| peer\_route\_4\_enable | Enables Peer Route Table 4. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `bool` | `false` | no |
+| peer\_route\_4\_table\_id | ID of VPC Route table #4 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `string` | `""` | no |
+| peer\_route\_5\_enable | Enables Peer Route Table 5. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `bool` | `false` | no |
+| peer\_route\_5\_table\_id | ID of VPC Route table #5 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables. | `string` | `""` | no |
+| peer\_route\_tables | A list of all peer route tables IDs | `list(string)` | `[]` | no |
+| peer\_route\_tables\_count | The number of peer route tables | `number` | `0` | no |
 | peer\_vpc\_id | The ID of the VPC with which you are creating the VPC Peering Connection. | `string` | n/a | yes |
 | tags | Custom tags to apply to all resources. | `map(string)` | `{}` | no |
 | vpc\_id | The ID of the requester VPC. | `string` | n/a | yes |
-| vpc\_route\_1\_enable | Enables VPC Route Table 1. Allowed values: true, false | `bool` | `false` | no |
-| vpc\_route\_1\_table\_id | ID of VPC Route table #1 rtb-XXXXXX | `string` | `""` | no |
-| vpc\_route\_2\_enable | Enables VPC Route Table 2. Allowed values: true, false | `bool` | `false` | no |
-| vpc\_route\_2\_table\_id | ID of VPC Route table #2 rtb-XXXXXX | `string` | `""` | no |
-| vpc\_route\_3\_enable | Enables VPC Route Table 3. Allowed values: true, false | `bool` | `false` | no |
-| vpc\_route\_3\_table\_id | ID of VPC Route table #3 rtb-XXXXXX | `string` | `""` | no |
-| vpc\_route\_4\_enable | Enables VPC Route Table 4. Allowed values: true, false | `bool` | `false` | no |
-| vpc\_route\_4\_table\_id | ID of VPC Route table #4 rtb-XXXXXX | `string` | `""` | no |
-| vpc\_route\_5\_enable | Enables VPC Route Table 5. Allowed values: true, false | `bool` | `false` | no |
-| vpc\_route\_5\_table\_id | ID of VPC Route table #5 rtb-XXXXXX | `string` | `""` | no |
+| vpc\_route\_1\_enable | Enables VPC Route Table 1. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `bool` | `false` | no |
+| vpc\_route\_1\_table\_id | ID of VPC Route table #1 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `string` | `""` | no |
+| vpc\_route\_2\_enable | Enables VPC Route Table 2. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `bool` | `false` | no |
+| vpc\_route\_2\_table\_id | ID of VPC Route table #2 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `string` | `""` | no |
+| vpc\_route\_3\_enable | Enables VPC Route Table 3. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `bool` | `false` | no |
+| vpc\_route\_3\_table\_id | ID of VPC Route table #3 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `string` | `""` | no |
+| vpc\_route\_4\_enable | Enables VPC Route Table 4. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `bool` | `false` | no |
+| vpc\_route\_4\_table\_id | ID of VPC Route table #4 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `string` | `""` | no |
+| vpc\_route\_5\_enable | Enables VPC Route Table 5. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `bool` | `false` | no |
+| vpc\_route\_5\_table\_id | ID of VPC Route table #5 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables. | `string` | `""` | no |
+| vpc\_route\_tables | A list of all VPC route tables IDs | `list(string)` | `[]` | no |
+| vpc\_route\_tables\_count | The number of VPC route tables | `number` | `0` | no |
 
 ## Outputs
 

--- a/modules/vpc_peer_cross_account/examples/cross_account.tf
+++ b/modules/vpc_peer_cross_account/examples/cross_account.tf
@@ -20,7 +20,7 @@ provider "aws" {
 }
 
 module "base_network" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.4"
 
   cidr_range          = "172.18.0.0/16"
   name                = "VPC-Peer-Origin"
@@ -29,18 +29,14 @@ module "base_network" {
 }
 
 module "cross_account_vpc_peer" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_peer//modules/vpc_peer_cross_account?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_peer//modules/vpc_peer_cross_account?ref=v0.12.2"
 
-  peer_route_1_enable   = true
-  peer_route_1_table_id = "rtb-XXXXXX"
-  peer_route_2_enable   = true
-  peer_route_2_table_id = "rtb-XXXXX"
-  peer_vpc_id           = "vpc-XXXXXXXXX"
-  vpc_id                = module.base_network.vpc_id
-  vpc_route_1_enable    = true
-  vpc_route_1_table_id  = element(module.base_network.private_route_tables, 0)
-  vpc_route_2_enable    = true
-  vpc_route_2_table_id  = element(module.base_network.private_route_tables, 1)
+  peer_route_tables       = ["rtb-xxxxxxxx", "rtb-yyyyyyyy"]
+  peer_route_tables_count = 2
+  peer_vpc_id             = "vpc-XXXXXXXXX"
+  vpc_id                  = module.base_network.vpc_id
+  vpc_route_tables        = module.base_network.private_route_tables
+  vpc_route_tables_count  = 2
 
   providers = {
     aws = aws.peer

--- a/modules/vpc_peer_cross_account/examples/inter_region.tf
+++ b/modules/vpc_peer_cross_account/examples/inter_region.tf
@@ -16,7 +16,7 @@ provider "aws" {
 data "aws_caller_identity" "current" {}
 
 module "base_network" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.4"
 
   cidr_range          = "172.18.0.0/16"
   custom_azs          = ["us-west-2a", "us-west-2b"]
@@ -26,7 +26,7 @@ module "base_network" {
 }
 
 module "base_network_target" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.4"
 
   cidr_range          = "172.19.0.0/16"
   custom_azs          = ["us-east-1a", "us-east-1b"]
@@ -40,18 +40,14 @@ module "base_network_target" {
 }
 
 module "cross_account_vpc_peer" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_peer//modules/vpc_peer_cross_account?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_peer//modules/vpc_peer_cross_account?ref=v0.12.2"
 
-  peer_route_1_enable   = true
-  peer_route_1_table_id = element(module.base_network_target.private_route_tables, 0)
-  peer_route_2_enable   = true
-  peer_route_2_table_id = element(module.base_network_target.private_route_tables, 1)
-  peer_vpc_id           = module.base_network_target.vpc_id
-  vpc_id                = module.base_network.vpc_id
-  vpc_route_1_enable    = true
-  vpc_route_1_table_id  = element(module.base_network.private_route_tables, 0)
-  vpc_route_2_enable    = true
-  vpc_route_2_table_id  = element(module.base_network.private_route_tables, 1)
+  peer_route_tables       = module.base_network_target.private_route_tables
+  peer_route_tables_count = 2
+  peer_vpc_id             = module.base_network_target.vpc_id
+  vpc_id                  = module.base_network.vpc_id
+  vpc_route_tables        = module.base_network.private_route_tables
+  vpc_route_tables_count  = 2
 
   providers = {
     aws.peer = aws.peer

--- a/modules/vpc_peer_cross_account/variables.tf
+++ b/modules/vpc_peer_cross_account/variables.tf
@@ -10,66 +10,77 @@ variable "environment" {
   default     = "Development"
 }
 
+variable "peer_route_tables" {
+  description = "A list of all peer route tables IDs"
+  type        = list(string)
+  default     = []
+}
+
+variable "peer_route_tables_count" {
+  description = "The number of peer route tables"
+  type        = number
+  default     = 0
+}
+
 variable "peer_route_1_enable" {
-  description = "Enables Peer Route Table 1. Allowed values: true, false"
+  description = "Enables Peer Route Table 1. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "peer_route_1_table_id" {
-  description = "ID of VPC Route table #1 rtb-XXXXXX"
+  description = "ID of VPC Route table #1 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = string
   default     = ""
 }
 
 variable "peer_route_2_enable" {
-  description = "Enables Peer Route Table 2. Allowed values: true, false"
+  description = "Enables Peer Route Table 2. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "peer_route_2_table_id" {
-  description = "ID of VPC Route table #2 rtb-XXXXXX"
+  description = "ID of VPC Route table #2 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = string
   default     = ""
 }
 
 variable "peer_route_3_enable" {
-  description = "Enables Peer Route Table 3. Allowed values: true, false"
+  description = "Enables Peer Route Table 3. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "peer_route_3_table_id" {
-  description = "ID of VPC Route table #3 rtb-XXXXXX"
+  description = "ID of VPC Route table #3 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = string
   default     = ""
 }
 
 variable "peer_route_4_enable" {
-  description = "Enables Peer Route Table 4. Allowed values: true, false"
+  description = "Enables Peer Route Table 4. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "peer_route_4_table_id" {
-  description = "ID of VPC Route table #4 rtb-XXXXXX"
+  description = "ID of VPC Route table #4 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = string
   default     = ""
 }
 
 variable "peer_route_5_enable" {
-  description = "Enables Peer Route Table 5. Allowed values: true, false"
+  description = "Enables Peer Route Table 5. (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "peer_route_5_table_id" {
-  description = "ID of VPC Route table #5 rtb-XXXXXX"
+  description = "ID of VPC Route table #5 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `peer_route_tables` and `peer_route_tables_count` variables."
   type        = string
   default     = ""
 }
-
 variable "peer_vpc_id" {
   description = "The ID of the VPC with which you are creating the VPC Peering Connection."
   type        = string
@@ -86,62 +97,74 @@ variable "vpc_id" {
   type        = string
 }
 
+variable "vpc_route_tables" {
+  description = "A list of all VPC route tables IDs"
+  type        = list(string)
+  default     = []
+}
+
+variable "vpc_route_tables_count" {
+  description = "The number of VPC route tables"
+  type        = number
+  default     = 0
+}
+
 variable "vpc_route_1_enable" {
-  description = "Enables VPC Route Table 1. Allowed values: true, false"
+  description = "Enables VPC Route Table 1. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "vpc_route_1_table_id" {
-  description = "ID of VPC Route table #1 rtb-XXXXXX"
+  description = "ID of VPC Route table #1 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = string
   default     = ""
 }
 
 variable "vpc_route_2_enable" {
-  description = "Enables VPC Route Table 2. Allowed values: true, false"
+  description = "Enables VPC Route Table 2. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "vpc_route_2_table_id" {
-  description = "ID of VPC Route table #2 rtb-XXXXXX"
+  description = "ID of VPC Route table #2 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = string
   default     = ""
 }
 
 variable "vpc_route_3_enable" {
-  description = "Enables VPC Route Table 3. Allowed values: true, false"
+  description = "Enables VPC Route Table 3. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "vpc_route_3_table_id" {
-  description = "ID of VPC Route table #3 rtb-XXXXXX"
+  description = "ID of VPC Route table #3 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = string
   default     = ""
 }
 
 variable "vpc_route_4_enable" {
-  description = "Enables VPC Route Table 4. Allowed values: true, false"
+  description = "Enables VPC Route Table 4. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "vpc_route_4_table_id" {
-  description = "ID of VPC Route table #4 rtb-XXXXXX"
+  description = "ID of VPC Route table #4 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = string
   default     = ""
 }
 
 variable "vpc_route_5_enable" {
-  description = "Enables VPC Route Table 5. Allowed values: true, false"
+  description = "Enables VPC Route Table 5. (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = bool
   default     = false
 }
 
 variable "vpc_route_5_table_id" {
-  description = "ID of VPC Route table #5 rtb-XXXXXX"
+  description = "ID of VPC Route table #5 rtb-XXXXXX (Deprecated) This variable will be removed in future releases in favor of the `vpc_route_tables` and `vpc_route_tables_count` variables."
   type        = string
   default     = ""
 }

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -49,8 +49,12 @@ module "vpc_peer" {
 
   allow_remote_vpc_dns_resolution = true
   auto_accept                     = true
+  peer_route_tables               = concat(module.peer_base_network.public_route_tables, module.peer_base_network.private_route_tables)
+  peer_route_tables_count         = 3
   peer_vpc_id                     = module.peer_base_network.vpc_id
   vpc_id                          = module.base_network.vpc_id
+  vpc_route_tables                = concat(module.base_network.public_route_tables, module.base_network.private_route_tables)
+  vpc_route_tables_count          = 3
 }
 
 data "aws_caller_identity" "current" {
@@ -59,16 +63,12 @@ data "aws_caller_identity" "current" {
 module "cross_account_vpc_peer" {
   source = "../../module/modules/vpc_peer_cross_account"
 
-  peer_route_1_enable   = true
-  peer_route_1_table_id = element(module.remote_peer_base_network.private_route_tables, 0)
-  peer_route_2_enable   = true
-  peer_route_2_table_id = element(module.remote_peer_base_network.private_route_tables, 1)
-  peer_vpc_id           = module.remote_peer_base_network.vpc_id
-  vpc_id                = module.base_network.vpc_id
-  vpc_route_1_enable    = true
-  vpc_route_1_table_id  = element(module.base_network.private_route_tables, 0)
-  vpc_route_2_enable    = true
-  vpc_route_2_table_id  = element(module.base_network.private_route_tables, 1)
+  peer_route_tables       = concat(module.remote_peer_base_network.public_route_tables, module.remote_peer_base_network.private_route_tables)
+  peer_route_tables_count = 3
+  peer_vpc_id             = module.remote_peer_base_network.vpc_id
+  vpc_id                  = module.base_network.vpc_id
+  vpc_route_tables        = concat(module.base_network.public_route_tables, module.base_network.private_route_tables)
+  vpc_route_tables_count  = 3
 
   providers = {
     aws.peer = aws.ohio


### PR DESCRIPTION
##### Corresponding Issue(s):
 - [MPCSUPENG-999](https://jira.rax.io/browse/MPCSUPENG-999)
 
##### Summary of change(s):
- Adds variable for list of peer route tables and peer route table count
- Adds variable for list of vpc route tables and vpc route table count
- Create all VPC routes from a single logical resource
- Create al Peer routes from a single logical resource
- Existing individual resources and associated variables left in module and marked deprecated.  They should be removed during next major version update.
- New route resources have dependencies on legacy routes, to ensure conflict-free transition between old and new style
##### Reason for Change(s):
 More efficient module declaration

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
Not directly, however moving from the original declarations to the new style would cause the route entries to be destroyed and recreated. 
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
Yes readmes have been updated
##### Do examples need to be updated based on changes?
Yes, examples were updated
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
